### PR TITLE
Fix temperature parameter name

### DIFF
--- a/utils/GenerateCodeServer.ts
+++ b/utils/GenerateCodeServer.ts
@@ -27,7 +27,7 @@ export async function generateCode(prompt: String, currentCode?: string): Promis
             model: 'qwen2.5-coder',
             messages,
             stream: false,
-            temperatur: 0.0,
+            temperature: 0.0,
             tools: [
                 {
                     type: 'function',

--- a/utils/GeneratePromptServer.ts
+++ b/utils/GeneratePromptServer.ts
@@ -23,7 +23,7 @@ export async function generatePrompt(image: String, prompt?: String): Promise<st
                 }
             ],
             stream: false,
-            temperatur: 0.5,
+            temperature: 0.5,
             tools: [
                 {
                     type: 'function',


### PR DESCRIPTION
## Summary
- send the `temperature` field correctly to the Ollama API

## Testing
- `bun install`
- `npx eslint utils/GeneratePromptServer.ts utils/GenerateCodeServer.ts` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68430107979c8322b2601d58d34e54d2