### PR TITLE
Fix String type annotations

### DIFF
--- a/types/Ollama.ts
+++ b/types/Ollama.ts
@@ -1,10 +1,10 @@
 export interface OllamaResponse<T> {
-    model: String,
-    created_at: String,
+    model: string,
+    created_at: string,
     message: {
-        role: String,
-        content: String,
-        images?: String[],
+        role: string,
+        content: string,
+        images?: string[],
         tool_calls?: T[]
     },
     done: boolean,
@@ -18,7 +18,7 @@ export interface OllamaResponse<T> {
 
 export interface OllamaPromptResponse {
     function: {
-        name: String,
+        name: string,
         arguments: {
             description: string
         }
@@ -27,7 +27,7 @@ export interface OllamaPromptResponse {
 
 export interface OllamaCodeResponse {
     function: {
-        name: String,
+        name: string,
         arguments: {
             content: string
         }

--- a/types/PromptBody.ts
+++ b/types/PromptBody.ts
@@ -1,8 +1,8 @@
 export interface ImagePromptBody {
-    prompt?: String,
-    image: String
+    prompt?: string,
+    image: string
 }
 
 export interface PromptBody {
-    prompt: String
+    prompt: string
 }

--- a/utils/GenerateCodeClient.ts
+++ b/utils/GenerateCodeClient.ts
@@ -1,6 +1,6 @@
 import type { PromptBody, ImagePromptBody } from "~/types/PromptBody";
 
-export async function generateWithImage(image: String, prompt?: String): Promise<GeneratedResponse> {
+export async function generateWithImage(image: string, prompt?: string): Promise<GeneratedResponse> {
     let request: ImagePromptBody = {
          image,
          prompt
@@ -15,7 +15,7 @@ export async function generateWithImage(image: String, prompt?: String): Promise
     });
 }
 
-export async function generate(prompt: String, id: String): Promise<GeneratedResponse> {
+export async function generate(prompt: string, id: string): Promise<GeneratedResponse> {
     let request: PromptBody = {
          prompt
     };

--- a/utils/GenerateCodeServer.ts
+++ b/utils/GenerateCodeServer.ts
@@ -1,7 +1,7 @@
 import type { OllamaResponse, OllamaCodeResponse } from '~/types/Ollama';
 import chalk from 'chalk';
 
-export async function generateCode(prompt: String, currentCode?: string): Promise<string> {
+export async function generateCode(prompt: string, currentCode?: string): Promise<string> {
     const messages = [];
     messages.push({
         role: 'system',

--- a/utils/GeneratePromptServer.ts
+++ b/utils/GeneratePromptServer.ts
@@ -1,7 +1,7 @@
 import type { OllamaResponse, OllamaPromptResponse } from '~/types/Ollama';
 import chalk from 'chalk';
 
-export async function generatePrompt(image: String, prompt?: String): Promise<string> {
+export async function generatePrompt(image: string, prompt?: string): Promise<string> {
     let result: OllamaResponse<OllamaPromptResponse> = await (await fetch('http://localhost:11434/api/chat', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- replace boxed `String` type annotations with primitive `string`

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_684302ce823c83229d21ade100b437fe